### PR TITLE
Name of node binary has changed from node to nodejs

### DIFF
--- a/http/examples/node
+++ b/http/examples/node
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env nodejs
 
 var sqlite3 = require('sqlite3')
 


### PR DESCRIPTION
Name of node binary is no longer node, but nodejs - see https://github.com/scraperwiki/custard/issues/294 and https://twitter.com/airpoint/status/350622919124205568
