### PR TITLE
Add an empty MAILTO to crontabs

### DIFF
--- a/crontab-daily
+++ b/crontab-daily
@@ -1,3 +1,4 @@
+MAILTO=""
 SHELL=/bin/bash
 
 # THIS_IS_DAILY

--- a/crontab-hourly
+++ b/crontab-hourly
@@ -1,3 +1,4 @@
+MAILTO=""
 SHELL=/bin/bash
 
 # THIS_IS_HOURLY

--- a/crontab-monthly
+++ b/crontab-monthly
@@ -1,3 +1,4 @@
+MAILTO=""
 SHELL=/bin/bash
 
 # THIS_IS_MONTHLY


### PR DESCRIPTION
Prevent email spam to /var/log on cobalt; any STDOUT or STDERR gets sent
there, which, together with the mail headers, can accumulate over time
to use considerable disk space. This can then run out and cause error
messages to be regularly sent to us warning us of no disk space for
/var/log.

If someone wants to set a valid email, they'd have to specify this
anyway. And users don't have access to /var/log.